### PR TITLE
Make BAM! actually run correctly

### DIFF
--- a/bam/examples/factorial.bam
+++ b/bam/examples/factorial.bam
@@ -1,0 +1,5 @@
+machine Factorial {
+    ((!input, 1) -> Lt)
+        ? 1
+        : (((!input, 1) -> Sub -> Factorial), input) -> Mul
+}

--- a/bam/src/compiler.rs
+++ b/bam/src/compiler.rs
@@ -1,0 +1,77 @@
+//! BAM! bytecode compiler.
+
+use std::collections::{HashMap, VecDeque};
+
+use crate::{syntax::Value, vm::SharedStream, Builtin, Program, Statement, Stream};
+
+/// Local handle to a [`FlatStream`].
+pub struct Symbol(u32);
+
+/// Compiled version of a stream.
+pub enum Flow {
+    /// Always return the same value. Boring!
+    Const(Value),
+    /// Consume from the underlying stream a limited number of times.
+    Take(Symbol, u32),
+    /// Consume from the underlying stream without changing it.
+    Peek(Symbol),
+    /// Adds a cache to some stream.
+    Cache(Symbol, VecDeque<Value>),
+}
+
+/// Compiled version of a machine.
+pub enum Unit {
+    Instrs(Vec<Instr>),
+    Builtin(Builtin),
+}
+
+/// Machine instructions.
+pub enum Instr {
+    /// Create a shared stream in the current task
+    /// and bind it to the given symbol.
+    Make(Symbol, Flow),
+    /// Consume a value from this stream and return it.
+    /// INVARIANT: the last element is always of this variant.
+    Next(Symbol),
+    /// Run a unit with a tuple of streams,
+    /// and return a value from it.
+    /// FIXME: does the unit need a name?
+    Exec(Vec<Symbol>, String),
+}
+
+/// Compiled program.
+pub struct Code(HashMap<String, Unit>);
+
+/// Compiler context.
+pub struct Compiler {
+    /// Collected units, correspond to machines.
+    units: HashMap<String, Unit>,
+    /// Symbol counter, resets to zero after each machine compilation.
+    symbols: u32,
+}
+
+impl Compiler {
+    /// Create a compiler.
+    pub fn new() -> Self {
+        Compiler {
+            units: HashMap::new(),
+            symbols: 0,
+        }
+    }
+
+    /// Transform a syntax tree into a mostly flat representation.
+    pub fn transform(&mut self, program: Program) -> Code {
+        Code(
+            program
+                .machines
+                .into_iter()
+                .map(|m| (m.name, self.transform_machine(m.body, m.result)))
+                .collect::<HashMap<_, _>>(),
+        )
+    }
+
+    /// Transform a machine into a unit.
+    pub fn transform_machine(&mut self, body: Vec<Statement>, result: Stream) -> Unit {
+        todo!()
+    }
+}

--- a/bam/src/eval.rs
+++ b/bam/src/eval.rs
@@ -2,44 +2,257 @@ use crate::{
     syntax::{Builtin, Machine, Program, Statement, Stream, Value},
     Definition,
 };
-use std::cell::RefCell;
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::io::stdin;
+use std::rc::Rc;
+use std::{borrow::Borrow, cell::RefCell};
 
 use anyhow::{anyhow, bail, Context, Result};
 use tracing::info;
 
+/// Execution context of a single machine.
+/// Holds local variables.
+#[derive(Debug)]
+pub struct Task {
+    locals: HashMap<String, Stream>,
+}
+
+impl Task {
+    /// Create a new, empty Task.
+    pub fn new(input: &mut Stream) -> Self {
+        let mut locals = HashMap::new();
+
+        input.share();
+        locals.insert(String::from("input"), input.clone());
+
+        Task { locals }
+    }
+
+    /// Bind a stream in the local environment.
+    pub fn bind(&mut self, name: String, stream: Stream) {
+        self.locals.insert(name, stream);
+    }
+
+    /// Resolve a stream from the local environmnt.
+    pub fn resolve(&self, name: &str) -> Result<&Stream> {
+        self.locals
+            .get(name)
+            .ok_or(anyhow!("Undefined fantastic (local) stream"))
+    }
+}
+
 /// BAM! execution engine.
 pub struct Factory {
-    machines: RefCell<HashMap<String, Machine>>,
-    streams: RefCell<HashMap<String, Stream>>,
+    machines: HashMap<String, Machine>,
+    tasks: RefCell<Vec<Task>>,
+    current: RefCell<Option<usize>>,
 }
 
 impl Factory {
     /// Create a factory given the abstract syntax tree.
     pub fn new(program: Program) -> Self {
         Factory {
-            machines: RefCell::new(
-                program
-                    .machines
-                    .into_iter()
-                    .map(|m| (m.name.clone(), Machine::Defined(m.body, m.result)))
-                    .collect(),
-            ),
-            streams: RefCell::new(HashMap::new()),
+            machines: program
+                .machines
+                .into_iter()
+                .map(|m| (m.name.clone(), Machine::Defined(m.body, m.result)))
+                .collect(),
+            tasks: RefCell::new(Vec::new()),
+            current: RefCell::new(None),
         }
     }
 
-    // Add a named machine to the factory from a definition.
-    pub fn bind_definition(&self, name: String, machine: Definition) {
-        // TODO: handle Borrow errors.
+    /// Add a named machine to the factory from a definition.
+    pub fn bind_definition(&mut self, name: String, machine: Definition) {
         self.machines
-            .borrow_mut()
             .insert(name, Machine::Defined(machine.body, machine.result));
     }
 
+    /// Get the next element from the stream.
+    pub fn advance_stream(&self, stream: &mut Stream) -> Result<Value> {
+        match stream {
+            Stream::Local(stream, index) => {
+                info!(
+                    "[EVAL] Advancing Local: '{:#?} at task = {:#?}'",
+                    stream, index
+                );
+
+                let current = *self.current.borrow();
+                *self.current.borrow_mut() = Some(*index);
+
+                let val = self.advance_stream(stream)?;
+
+                *self.current.borrow_mut() = current;
+
+                Ok(val)
+            }
+            Stream::Var(var) => {
+                info!("[EVAL] Advancing Var: '{:#?}'", var);
+
+                // INVARIANT: shared streams like 'input' are always behind Share
+
+                let mut tasks = self.tasks.borrow();
+                let current = *self.current.borrow();
+                let task = tasks.get(current.unwrap()).ok_or(anyhow!(
+                    "Stack pointer {:?} out of bound {:#?}",
+                    current,
+                    tasks
+                ))?;
+
+                match task.resolve(var)? {
+                    Stream::Share(s) => {
+                        // let mut s = s.try_borrow_mut().with_context(|| {
+                        //     format!("Cannot mutate shared stream `{}` because Rust.", var)
+                        // })?;
+                        let s = unsafe { s.as_ptr().as_mut().unwrap() };
+                        self.advance_stream(s)
+                    }
+                    other => bail!(
+                        "Cannot reference non-shared stream: {} = `{:#?}`",
+                        var,
+                        other
+                    ),
+                }
+            }
+            Stream::Const(val) => {
+                info!("[EVAL] Advancing Const: '{:#?}'", val);
+
+                Ok(val.clone())
+            }
+            Stream::Pipe(stream, machine) => {
+                info!("[EVAL] Advancing Pipe: {:#?} -> {:#?}", stream, &machine);
+
+                stream.local(self.current.borrow().unwrap());
+                stream.share();
+                self.run_machine(*machine.clone(), stream)
+            }
+            Stream::Zip(streams) => {
+                info!("[EVAL] Advancing Zip: {:#?}", streams);
+
+                streams
+                    .iter_mut()
+                    .map(|s| self.advance_stream(s))
+                    .collect::<Result<Vec<_>>>()
+                    .map(Value::Tuple)
+            }
+            Stream::Cond(cond_stream, then_stream, else_stream) => {
+                info!(
+                    "[EVAL] Advancing Cond: if {:#?} then {:#?} else {:#?}",
+                    cond_stream, then_stream, else_stream
+                );
+
+                let val = self.advance_stream(cond_stream)?;
+                info!("[EVAL] Cond recieved {:?} => {}", cond_stream, val.clone());
+                if let Value::Bool(cond) = val {
+                    if cond {
+                        self.advance_stream(then_stream)
+                    } else {
+                        self.advance_stream(else_stream)
+                    }
+                } else {
+                    bail!("Non-bool value in conditional")
+                }
+            }
+            Stream::Take(stream, limit) => {
+                info!("[EVAL] Advancing Take: {:#?}[{limit}]", stream);
+
+                if *limit == 0 {
+                    Ok(Value::Null)
+                } else {
+                    *limit -= 1;
+                    self.advance_stream(stream)
+                }
+            }
+            Stream::Peek(stream) => {
+                info!("[EVAL] Advancing Peek: {:#?}", stream);
+
+                // INVARIANT: Peek always has a hold behind it, evantually.
+                match &mut **stream {
+                    // We already created a cache at this level, use it.
+                    Stream::Hold(protected_stream, cache) => match cache.back().cloned() {
+                        None => {
+                            let val = self.advance_stream(protected_stream)?;
+                            cache.push_front(val.clone());
+                            Ok(val)
+                        }
+                        Some(val) => Ok(val),
+                    },
+                    stream => {
+                        let val = self.advance_stream(stream)?;
+                        let mut cache = VecDeque::new();
+                        cache.push_front(val.clone());
+
+                        let old_stream = std::mem::take(stream);
+                        /* Nothing should access the stream here, it's Null */
+                        let new_stream = Stream::Hold(Box::new(old_stream), cache);
+                        std::mem::replace(stream, new_stream);
+
+                        Ok(val)
+                    }
+                }
+            }
+            Stream::Proj(stream, index) => {
+                info!("Advancing Proj: {:#?}, at {}", stream, index);
+
+                if let Value::Tuple(values) = self.advance_stream(stream)? {
+                    info!("Unwrapping {:#?} in Unzip, at {}", values, index);
+
+                    match values.get(*index) {
+                        Some(value) => Ok(value.clone()),
+                        None => bail!("Bad index in unzip: {}", *index),
+                    }
+                    // values -- WTF???
+                    //     .get(index)
+                    //     .ok_or(bail!("Bad index in unzip: {}", index))
+                    //     .cloned()
+                } else {
+                    bail!("Called unzip on non-tupled stream: {:?}", stream)
+                }
+            }
+            Stream::Hold(stream, cache) => {
+                info!("Advancing Hold: {:#?} | {:?}", stream, cache);
+
+                // INVARIANT: A Hold with no Peek protecting it invalidates its cache.
+                match cache.back().cloned() {
+                    None => self.advance_stream(stream),
+                    Some(val) => Ok(val),
+                }
+            }
+            Stream::Share(stream) => {
+                info!("Advancing Share: {:#?}", stream);
+
+                let mut stream = stream
+                    .try_borrow_mut()
+                    .context(format!("Could not mutate shared stream"))?;
+                self.advance_stream(&mut stream)
+            }
+        }
+    }
+
+    /// Perform one step of a machine's evaluation.
+    pub fn run_machine(&self, machine: Machine, input: &mut Stream) -> Result<Value> {
+        let val = match machine {
+            Machine::Var(var) => self.run_machine(
+                self.machines
+                    .get(&var)
+                    .cloned()
+                    .ok_or(anyhow!("Undefined fantastic machine: {}", var))?,
+                input,
+            ),
+            Machine::Builtin(builtin) => self.run_builtin_machine(builtin, input),
+            Machine::Defined(body, result) => self.run_defined_machine(body, result, input),
+        }?;
+
+        info!("[EVAL] Machine returned: {:#?}", val);
+        Ok(val)
+    }
+
     /// Perform one step of builtin machine evaluation.
-    pub fn run_builtin_machine(&self, builtin: &Builtin, value: Value) -> Result<Value> {
+    pub fn run_builtin_machine(&self, builtin: Builtin, input: &mut Stream) -> Result<Value> {
+        info!("Running builtin {:#?} with input = {:#?}", builtin, input);
+
+        let value = self.advance_stream(input)?;
         match builtin {
             Builtin::Add => {
                 let (lhs, rhs) = value.to_pair();
@@ -128,126 +341,60 @@ impl Factory {
         }
     }
 
-    /// Run a machine statement, corresponds to one step in the REPL.
-    pub fn run_statement(&self, stmt: &mut Statement) -> Result<Option<Value>> {
-        match stmt {
-            Statement::Let(names, stream) => {
-                if names.len() == 1 {
-                    self.streams
-                        .try_borrow_mut()
-                        .map(|mut ss| ss.insert(names.get(0).unwrap().clone(), stream.clone()))
-                        .with_context(|| format!("Unable to access streams"))?;
-                } else {
-                    for (index, name) in names.iter().enumerate() {
-                        let stream = Stream::Unzip(Box::new(stream.clone()), index);
-                        self.streams
-                            .try_borrow_mut()
-                            .map(|mut ss| ss.insert(name.clone(), stream))
-                            .with_context(|| format!("Unable to access streams"))?;
-                    }
-                }
-                Ok(None)
-            }
-            Statement::Consume(stream) => Ok(Some(self.advance_stream(stream)?)),
-        }
-    }
-
     /// Perform one step of user-supplied machine evaluation.
     pub fn run_defined_machine(
         &self,
-        body: &mut [Statement],
-        result: &mut Stream,
-        value: Value,
+        mut body: Vec<Statement>,
+        mut result: Stream,
+        input: &mut Stream,
     ) -> Result<Value> {
-        self.streams
-            .borrow_mut()
-            .insert("input".to_string(), Stream::Const(value));
+        info!(
+            "Running machine ({:#?}, {:#?}) with input = {:#?}",
+            body, result, input
+        );
 
-        for mut stmt in body {
-            self.run_statement(stmt);
-        }
+        let mut task = Task::new();
 
-        self.advance_stream(result)
-    }
+        // INVARIANT: running a machine always stored its locals on top of the stack.
+        task.bind(String::from("input"), input.clone());
+        self.tasks.borrow_mut().push(task);
+        self.current.borrow_mut().as_mut().map(|x| *x = *x + 1);
 
-    /// Perform one step of a machine's evaluation.
-    pub fn run_machine(&self, machine: &mut Machine, value: Value) -> Result<Value> {
-        match machine {
-            Machine::Var(var) => {
-                let mut machines = self.machines.borrow_mut();
+        for mut stmt in &mut body {
+            match stmt {
+                Statement::Let(names, stream) => {
+                    let mut tasks = self.tasks.borrow_mut();
+                    let index = tasks.len() - 1;
+                    let task = tasks.last_mut().ok_or(anyhow!("Empty task stack"))?;
 
-                info!("[EVAL] about to pull machine `{}` from the factory.", var);
-                info!("[EVAL] factory machines: {:#?}", machines);
-
-                self.run_machine(
-                    machines
-                        .get_mut(var)
-                        .ok_or(anyhow!("Undefined fantastic machine: {}", var))?,
-                    value,
-                )
-            }
-            Machine::Builtin(builtin) => self.run_builtin_machine(builtin, value),
-            Machine::Defined(body, result) => self.run_defined_machine(body, result, value),
-        }
-    }
-
-    /// Get the next element from the stream.
-    pub fn advance_stream(&self, stream: &mut Stream) -> Result<Value> {
-        match stream {
-            Stream::Var(var) => {
-                let mut streams = self
-                    .streams
-                    .try_borrow_mut()
-                    .with_context(|| format!("Unable to access streams"))?;
-
-                info!("[EVAL] about to pull stream `{}` from the factory.", var);
-                info!("[EVAL] factory streams: {:#?}", streams);
-
-                let stream = streams
-                    .get_mut(var)
-                    .ok_or(anyhow!("Undefined fantastic stream: {}", var))?;
-
-                self.advance_stream(stream)
-            }
-            Stream::Const(value) => Ok(value.clone()),
-            Stream::Pipe(stream, machine) => {
-                let value = self.advance_stream(stream)?;
-                self.run_machine(machine, value)
-            }
-            Stream::Zip(streams) => streams
-                .iter_mut()
-                .map(|s| self.advance_stream(s))
-                .collect::<Result<Vec<_>>>()
-                .map(Value::Tuple),
-            Stream::Unzip(stream, index) => {
-                if let Value::Tuple(values) = self.advance_stream(stream)? {
-                    values
-                        .get(*index)
-                        .cloned()
-                        .ok_or(bail!("bad index in unzip: {}", *index))
-                } else {
-                    bail!("called unzip on non-tupled stream: {:?}", stream)
-                }
-            }
-            Stream::Limit(stream, limit) => {
-                if *limit == 0 {
-                    Ok(Value::Null)
-                } else {
-                    *limit -= 1;
-                    self.advance_stream(stream)
-                }
-            }
-            Stream::Cond(cond_stream, then_stream, else_stream) => {
-                if let Value::Bool(cond) = self.advance_stream(cond_stream)? {
-                    if cond {
-                        self.advance_stream(then_stream)
+                    // Now to the tricky part.
+                    if names.len() == 1 {
+                        stream.local(index);
+                        stream.share();
+                        task.bind(names.get(0).unwrap().clone(), stream.clone());
                     } else {
-                        self.advance_stream(else_stream)
+                        for (index, name) in names.iter().enumerate() {
+                            let mut stream = Stream::Proj(Box::new(stream.clone()), index);
+                            stream.local(index);
+                            stream.share();
+                            task.bind(name.clone(), stream);
+                        }
                     }
-                } else {
-                    bail!("non-bool value in conditional")
+                }
+                Statement::Consume(stream) => {
+                    let stream = if stream.is_input() {
+                        &mut *input
+                    } else {
+                        stream
+                    };
+                    self.advance_stream(stream)?;
                 }
             }
         }
+
+        let val = self.advance_stream(&mut result);
+        self.tasks.borrow_mut().pop();
+        self.current.borrow_mut().as_mut().map(|x| *x = *x - 1);
+        val
     }
 }

--- a/bam/src/lexer.rs
+++ b/bam/src/lexer.rs
@@ -21,6 +21,7 @@ lazy_static! {
         "?" => Token::QuestionMark,
         ":" => Token::Colon,
         ";" => Token::Semicolon,
+        "!" => Token::Bang,
         "->" => Token::Pipe,
         "let" => Token::Let,
         "machine" => Token::Machine,
@@ -46,7 +47,8 @@ pub enum Token {
     Semicolon,
     Pipe,
     Machine,
-    Null
+    Null,
+    Bang
 }
 
 impl Display for Token {
@@ -131,6 +133,7 @@ impl LexerBuilder {
             just(":").to(Token::Colon),
             just(";").to(Token::Semicolon),
             just("->").to(Token::Pipe),
+            just("!").to(Token::Bang),
         ))
     }
 

--- a/bam/src/parser.rs
+++ b/bam/src/parser.rs
@@ -31,9 +31,13 @@ impl ParserBuilder {
                 .then_ignore(just(Token::Lbrace))
                 .then(Self::int())
                 .then_ignore(just(Token::Rbrace))
-                .map(|(stream, count)| Stream::Limit(Box::new(stream), count));
+                .map(|(stream, count)| Stream::Take(Box::new(stream), count));
 
-            let stream_limit = limit.or(stream_leaf.clone()).boxed();
+            let peek = just(Token::Bang)
+                .ignore_then(stream_leaf.clone())
+                .map(|stream| Stream::Peek(Box::new(stream)));
+
+            let stream_limit = peek.or(limit.or(stream_leaf.clone())).boxed();
 
             let stream_zip = stream_limit
                 .clone()

--- a/bam/src/vm.rs
+++ b/bam/src/vm.rs
@@ -1,0 +1,21 @@
+///! BAM! virtual machine.
+use std::{cell::RefCell, rc::Rc};
+
+use crate::compiler::{Flow, Unit};
+use lazy_static::lazy_static;
+
+/// A reference-counted, mutable stream in memory.
+pub struct SharedStream(Rc<RefCell<Flow>>);
+
+/// The execution context of one machine.
+pub struct Task {
+    /// Locally-reachable streams, indexed by symbols.
+    locals: Vec<SharedStream>,
+}
+
+/// Execution factory.
+pub struct Factory {
+    /// Call stack.
+    stack: Vec<Task>,
+}
+


### PR DESCRIPTION
This is a tracking PR for running BAM! on a _very high level_ virtual machine.

- `compiler.rs` would turn the syntax tree into a flatter, more machine friendly (get it?) representation.
- `vm.rs` would ... run that format.