### PR TITLE
Eval/make bam actually run correctly

### DIFF
--- a/bam/examples/factorial.bam
+++ b/bam/examples/factorial.bam
@@ -1,0 +1,5 @@
+machine Factorial {
+    ((!input, 1) -> Lt)
+        ? 1
+        : (((!input, 1) -> Sub -> Factorial), input) -> Mul
+}

--- a/bam/src/compiler.rs
+++ b/bam/src/compiler.rs
@@ -1,0 +1,77 @@
+//! BAM! bytecode compiler.
+
+use std::collections::{HashMap, VecDeque};
+
+use crate::{syntax::Value, vm::SharedStream, Builtin, Program, Statement, Stream};
+
+/// Local handle to a [`FlatStream`].
+pub struct Symbol(u32);
+
+/// Compiled version of a stream.
+pub enum Flow {
+    /// Always return the same value. Boring!
+    Const(Value),
+    /// Consume from the underlying stream a limited number of times.
+    Take(Symbol, u32),
+    /// Consume from the underlying stream without changing it.
+    Peek(Symbol),
+    /// Adds a cache to some stream.
+    Cache(Symbol, VecDeque<Value>),
+}
+
+/// Compiled version of a machine.
+pub enum Unit {
+    Instrs(Vec<Instr>),
+    Builtin(Builtin),
+}
+
+/// Machine instructions.
+pub enum Instr {
+    /// Create a shared stream in the current task
+    /// and bind it to the given symbol.
+    Make(Symbol, Flow),
+    /// Consume a value from this stream and return it.
+    /// INVARIANT: the last element is always of this variant.
+    Next(Symbol),
+    /// Run a unit with a tuple of streams,
+    /// and return a value from it.
+    /// FIXME: does the unit need a name?
+    Exec(Vec<Symbol>, String),
+}
+
+/// Compiled program.
+pub struct Code(HashMap<String, Unit>);
+
+/// Compiler context.
+pub struct Compiler {
+    /// Collected units, correspond to machines.
+    units: HashMap<String, Unit>,
+    /// Symbol counter, resets to zero after each machine compilation.
+    symbols: u32,
+}
+
+impl Compiler {
+    /// Create a compiler.
+    pub fn new() -> Self {
+        Compiler {
+            units: HashMap::new(),
+            symbols: 0,
+        }
+    }
+
+    /// Transform a syntax tree into a mostly flat representation.
+    pub fn transform(&mut self, program: Program) -> Code {
+        Code(
+            program
+                .machines
+                .into_iter()
+                .map(|m| (m.name, self.transform_machine(m.body, m.result)))
+                .collect::<HashMap<_, _>>(),
+        )
+    }
+
+    /// Transform a machine into a unit.
+    pub fn transform_machine(&mut self, body: Vec<Statement>, result: Stream) -> Unit {
+        todo!()
+    }
+}

--- a/bam/src/compiler.rs
+++ b/bam/src/compiler.rs
@@ -2,76 +2,235 @@
 
 use std::collections::{HashMap, VecDeque};
 
-use crate::{syntax::Value, vm::SharedStream, Builtin, Program, Statement, Stream};
+use crate::{syntax::Value, vm::SharedStream, Builtin, Machine, Program, Statement, Stream};
 
-/// Local handle to a [`FlatStream`].
+/// Local handle to a [`Flow`].
+#[derive(Copy, Clone)]
+pub struct Handle(u32);
+
+/// SSA-like symbol holding a [`Value`].
+#[derive(Copy, Clone)]
 pub struct Symbol(u32);
+
+/// Global handle to a [`Unit`].
+#[derive(Copy, Clone)]
+pub struct Number(u32);
 
 /// Compiled version of a stream.
 pub enum Flow {
     /// Always return the same value. Boring!
     Const(Value),
+    /// Stream of tuples.
+    Zip(Vec<Handle>),
     /// Consume from the underlying stream a limited number of times.
-    Take(Symbol, u32),
+    Take(Handle, usize),
     /// Consume from the underlying stream without changing it.
-    Peek(Symbol),
-    /// Adds a cache to some stream.
-    Cache(Symbol, VecDeque<Value>),
+    Peek(Handle),
+    /// Run a unit with a stream.
+    Pipe(Handle, Number),
+    /// Builtin operations.
+    Exec(Handle, Builtin),
+    /// Projection into a tuple value.
+    Proj(Handle, usize), // Value -> Value
+    /// Conditional stream.
+    Cond(Handle, Handle, Handle),
 }
 
 /// Compiled version of a machine.
-pub enum Unit {
-    Instrs(Vec<Instr>),
-    Builtin(Builtin),
+pub struct Unit(Vec<Instr>);
+
+impl Unit {
+    pub fn new() -> Self {
+        Self(Vec::new())
+    }
 }
 
 /// Machine instructions.
 pub enum Instr {
     /// Create a shared stream in the current task
     /// and bind it to the given symbol.
-    Make(Symbol, Flow),
-    /// Consume a value from this stream and return it.
-    /// INVARIANT: the last element is always of this variant.
-    Next(Symbol),
-    /// Run a unit with a tuple of streams,
-    /// and return a value from it.
-    /// FIXME: does the unit need a name?
-    Exec(Vec<Symbol>, String),
+    Make(Handle, Flow), // () -> Stream
+    /// Consume a value from this stream and drop it (?).
+    Next(Handle), // Stream -> Value
+    /// Return the given handle.
+    Eval(Handle),
 }
 
-/// Compiled program.
-pub struct Code(HashMap<String, Unit>);
-
-/// Compiler context.
-pub struct Compiler {
-    /// Collected units, correspond to machines.
-    units: HashMap<String, Unit>,
-    /// Symbol counter, resets to zero after each machine compilation.
-    symbols: u32,
+/// Renaming utility.
+pub struct Renamer {
+    map: HashMap<String, u32>,
+    count: u32,
 }
 
-impl Compiler {
-    /// Create a compiler.
-    pub fn new() -> Self {
-        Compiler {
-            units: HashMap::new(),
-            symbols: 0,
+impl Renamer {
+    /// Create a renamer.
+    fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            count: 0,
         }
     }
 
+    /// Bind a name in the renamer.
+    fn bind(&mut self, name: String) -> u32 {
+        match self.map.get(&name).cloned() {
+            None => {
+                self.count += 1;
+                self.map.insert(name, self.count);
+                self.count
+            }
+            Some(sym) => sym,
+        }
+    }
+
+    /// Get a fresh new symbol.
+    fn fresh(&mut self) -> u32 {
+        let sym = self.count;
+        self.count += 1;
+        sym
+    }
+}
+
+/// Compiler context, and also compiled code representation.
+pub struct Code {
+    /// Collected units, correspond to machines.
+    units: Vec<Unit>,
+    /// Symbol renamer.
+    symbols: Renamer,
+    /// Handle renamer.
+    handles: Renamer,
+    /// Number renamer.
+    numbers: Renamer,
+}
+
+impl Code {
+    /// Create a compiler.
+    pub fn new() -> Self {
+        Code {
+            units: Vec::new(),
+            symbols: Renamer::new(),
+            handles: Renamer::new(),
+            numbers: Renamer::new(),
+        }
+    }
+
+    /// Fresh number.
+    pub fn number(&mut self) -> Number {
+        Number(self.numbers.fresh())
+    }
+
+    /// Fresh handle.
+    pub fn handle(&mut self) -> Handle {
+        Handle(self.handles.fresh())
+    }
+
+    /// Fresh symbol.
+    pub fn symbol(&mut self) -> Symbol {
+        Symbol(self.symbols.fresh())
+    }
+
     /// Transform a syntax tree into a mostly flat representation.
-    pub fn transform(&mut self, program: Program) -> Code {
-        Code(
-            program
-                .machines
-                .into_iter()
-                .map(|m| (m.name, self.transform_machine(m.body, m.result)))
-                .collect::<HashMap<_, _>>(),
-        )
+    pub fn transform(&mut self, program: Program) {
+        for machine in program.machines {
+            self.transform_machine(machine.body, machine.result);
+        }
     }
 
     /// Transform a machine into a unit.
-    pub fn transform_machine(&mut self, body: Vec<Statement>, result: Stream) -> Unit {
-        todo!()
+    pub fn transform_machine(&mut self, body: Vec<Statement>, result: Stream) {
+        self.units.push(Unit::new());
+
+        for stmt in body {
+            self.transform_statement(stmt);
+        }
+
+        let handle = self.transform_stream(result);
+        self.add_instr(Instr::Eval(handle))
+    }
+
+    /// Transform a stream to a flow, pipes get
+    pub fn transform_statement(&mut self, stmt: Statement) {
+        match stmt {
+            // let x, y = stream;
+            Statement::Let(mut names, stream) => {
+                if names.len() == 1 {
+                    let name = names.pop().unwrap();
+                    let handle = Handle(self.handles.bind(name));
+                    self.transform_stream_with(stream, handle);
+                } else {
+                    let tuple = self.handle();
+                    self.transform_stream_with(stream, tuple);
+                    for (index, name) in names.into_iter().enumerate() {
+                        let handle = Handle(self.handles.bind(name));
+                        self.add_instr(Instr::Make(handle, Flow::Proj(tuple, index)))
+                    }
+                }
+            }
+            Statement::Consume(stream) => {
+                let handle = self.transform_stream(stream);
+                self.add_instr(Instr::Next(handle))
+            }
+        }
+    }
+
+    /// Transform a stream to a flow and give it the supplied handle.
+    pub fn transform_stream_with(&mut self, stream: Stream, handle: Handle) {
+        match stream {
+            Stream::Var(var) => {}
+            Stream::Const(val) => {
+                self.add_instr(Instr::Make(handle, Flow::Const(val)));
+            }
+            Stream::Pipe(stream, machine) => {
+                let input = self.transform_stream(*stream);
+                let flow = match *machine {
+                    Machine::Var(var) => Flow::Pipe(input, Number(self.numbers.bind(var))),
+                    Machine::Builtin(builtin) => Flow::Exec(input, builtin),
+                };
+
+                self.add_instr(Instr::Make(handle, flow));
+            }
+            Stream::Zip(streams) => {
+                let zipped = streams
+                    .into_iter()
+                    .map(|s| self.transform_stream(s))
+                    .collect::<Vec<_>>();
+
+                self.add_instr(Instr::Make(handle, Flow::Zip(zipped)));
+            }
+            Stream::Cond(cond, then, otherwise) => {
+                let cond = self.transform_stream(*cond);
+                let then = self.transform_stream(*then);
+                let otherwise = self.transform_stream(*otherwise);
+
+                self.add_instr(Instr::Make(handle, Flow::Cond(cond, then, otherwise)))
+            }
+            Stream::Take(stream, count) => {
+                let inner = self.transform_stream(*stream);
+
+                self.add_instr(Instr::Make(handle, Flow::Take(inner, count)))
+            }
+            Stream::Peek(stream) => {
+                let inner = self.transform_stream(*stream);
+
+                self.add_instr(Instr::Make(handle, Flow::Peek(inner)))
+            }
+        };
+    }
+
+    /// Helper function for [`transform_stream_with`].
+    pub fn transform_stream(&mut self, stream: Stream) -> Handle {
+        let handle = self.handle();
+        self.transform_stream_with(stream, handle);
+        handle
+    }
+
+    /// Add an instruction in the currently compiled unit.
+    pub fn add_instr(&mut self, instr: Instr) {
+        // TODO(fuzzypixelz): handle errors.
+        self.units
+            .last_mut()
+            .expect("no units in `add_instr`")
+            .0
+            .push(Instr::Make(Handle(0), Flow::Const(Value::Null)))
     }
 }

--- a/bam/src/eval.rs
+++ b/bam/src/eval.rs
@@ -2,44 +2,257 @@ use crate::{
     syntax::{Builtin, Machine, Program, Statement, Stream, Value},
     Definition,
 };
-use std::cell::RefCell;
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::io::stdin;
+use std::rc::Rc;
+use std::{borrow::Borrow, cell::RefCell};
 
 use anyhow::{anyhow, bail, Context, Result};
 use tracing::info;
 
+/// Execution context of a single machine.
+/// Holds local variables.
+#[derive(Debug)]
+pub struct Task {
+    locals: HashMap<String, Stream>,
+}
+
+impl Task {
+    /// Create a new, empty Task.
+    pub fn new(input: &mut Stream) -> Self {
+        let mut locals = HashMap::new();
+
+        input.share();
+        locals.insert(String::from("input"), input.clone());
+
+        Task { locals }
+    }
+
+    /// Bind a stream in the local environment.
+    pub fn bind(&mut self, name: String, stream: Stream) {
+        self.locals.insert(name, stream);
+    }
+
+    /// Resolve a stream from the local environmnt.
+    pub fn resolve(&self, name: &str) -> Result<&Stream> {
+        self.locals
+            .get(name)
+            .ok_or(anyhow!("Undefined fantastic (local) stream"))
+    }
+}
+
 /// BAM! execution engine.
 pub struct Factory {
-    machines: RefCell<HashMap<String, Machine>>,
-    streams: RefCell<HashMap<String, Stream>>,
+    machines: HashMap<String, Machine>,
+    tasks: RefCell<Vec<Task>>,
+    current: RefCell<Option<usize>>,
 }
 
 impl Factory {
     /// Create a factory given the abstract syntax tree.
     pub fn new(program: Program) -> Self {
         Factory {
-            machines: RefCell::new(
-                program
-                    .machines
-                    .into_iter()
-                    .map(|m| (m.name.clone(), Machine::Defined(m.body, m.result)))
-                    .collect(),
-            ),
-            streams: RefCell::new(HashMap::new()),
+            machines: program
+                .machines
+                .into_iter()
+                .map(|m| (m.name.clone(), Machine::Defined(m.body, m.result)))
+                .collect(),
+            tasks: RefCell::new(Vec::new()),
+            current: RefCell::new(None),
         }
     }
 
-    // Add a named machine to the factory from a definition.
-    pub fn bind_definition(&self, name: String, machine: Definition) {
-        // TODO: handle Borrow errors.
+    /// Add a named machine to the factory from a definition.
+    pub fn bind_definition(&mut self, name: String, machine: Definition) {
         self.machines
-            .borrow_mut()
             .insert(name, Machine::Defined(machine.body, machine.result));
     }
 
+    /// Get the next element from the stream.
+    pub fn advance_stream(&self, stream: &mut Stream) -> Result<Value> {
+        match stream {
+            Stream::Local(stream, index) => {
+                info!(
+                    "[EVAL] Advancing Local: '{:#?} at task = {:#?}'",
+                    stream, index
+                );
+
+                let current = *self.current.borrow();
+                *self.current.borrow_mut() = Some(*index);
+
+                let val = self.advance_stream(stream)?;
+
+                *self.current.borrow_mut() = current;
+
+                Ok(val)
+            }
+            Stream::Var(var) => {
+                info!("[EVAL] Advancing Var: '{:#?}'", var);
+
+                // INVARIANT: shared streams like 'input' are always behind Share
+
+                let mut tasks = self.tasks.borrow();
+                let current = *self.current.borrow();
+                let task = tasks.get(current.unwrap()).ok_or(anyhow!(
+                    "Stack pointer {:?} out of bound {:#?}",
+                    current,
+                    tasks
+                ))?;
+
+                match task.resolve(var)? {
+                    Stream::Share(s) => {
+                        // let mut s = s.try_borrow_mut().with_context(|| {
+                        //     format!("Cannot mutate shared stream `{}` because Rust.", var)
+                        // })?;
+                        let s = unsafe { s.as_ptr().as_mut().unwrap() };
+                        self.advance_stream(s)
+                    }
+                    other => bail!(
+                        "Cannot reference non-shared stream: {} = `{:#?}`",
+                        var,
+                        other
+                    ),
+                }
+            }
+            Stream::Const(val) => {
+                info!("[EVAL] Advancing Const: '{:#?}'", val);
+
+                Ok(val.clone())
+            }
+            Stream::Pipe(stream, machine) => {
+                info!("[EVAL] Advancing Pipe: {:#?} -> {:#?}", stream, &machine);
+
+                stream.local(self.current.borrow().unwrap());
+                stream.share();
+                self.run_machine(*machine.clone(), stream)
+            }
+            Stream::Zip(streams) => {
+                info!("[EVAL] Advancing Zip: {:#?}", streams);
+
+                streams
+                    .iter_mut()
+                    .map(|s| self.advance_stream(s))
+                    .collect::<Result<Vec<_>>>()
+                    .map(Value::Tuple)
+            }
+            Stream::Cond(cond_stream, then_stream, else_stream) => {
+                info!(
+                    "[EVAL] Advancing Cond: if {:#?} then {:#?} else {:#?}",
+                    cond_stream, then_stream, else_stream
+                );
+
+                let val = self.advance_stream(cond_stream)?;
+                info!("[EVAL] Cond recieved {:?} => {}", cond_stream, val.clone());
+                if let Value::Bool(cond) = val {
+                    if cond {
+                        self.advance_stream(then_stream)
+                    } else {
+                        self.advance_stream(else_stream)
+                    }
+                } else {
+                    bail!("Non-bool value in conditional")
+                }
+            }
+            Stream::Take(stream, limit) => {
+                info!("[EVAL] Advancing Take: {:#?}[{limit}]", stream);
+
+                if *limit == 0 {
+                    Ok(Value::Null)
+                } else {
+                    *limit -= 1;
+                    self.advance_stream(stream)
+                }
+            }
+            Stream::Peek(stream) => {
+                info!("[EVAL] Advancing Peek: {:#?}", stream);
+
+                // INVARIANT: Peek always has a hold behind it, evantually.
+                match &mut **stream {
+                    // We already created a cache at this level, use it.
+                    Stream::Hold(protected_stream, cache) => match cache.back().cloned() {
+                        None => {
+                            let val = self.advance_stream(protected_stream)?;
+                            cache.push_front(val.clone());
+                            Ok(val)
+                        }
+                        Some(val) => Ok(val),
+                    },
+                    stream => {
+                        let val = self.advance_stream(stream)?;
+                        let mut cache = VecDeque::new();
+                        cache.push_front(val.clone());
+
+                        let old_stream = std::mem::take(stream);
+                        /* Nothing should access the stream here, it's Null */
+                        let new_stream = Stream::Hold(Box::new(old_stream), cache);
+                        std::mem::replace(stream, new_stream);
+
+                        Ok(val)
+                    }
+                }
+            }
+            Stream::Proj(stream, index) => {
+                info!("Advancing Proj: {:#?}, at {}", stream, index);
+
+                if let Value::Tuple(values) = self.advance_stream(stream)? {
+                    info!("Unwrapping {:#?} in Unzip, at {}", values, index);
+
+                    match values.get(*index) {
+                        Some(value) => Ok(value.clone()),
+                        None => bail!("Bad index in unzip: {}", *index),
+                    }
+                    // values -- WTF???
+                    //     .get(index)
+                    //     .ok_or(bail!("Bad index in unzip: {}", index))
+                    //     .cloned()
+                } else {
+                    bail!("Called unzip on non-tupled stream: {:?}", stream)
+                }
+            }
+            Stream::Hold(stream, cache) => {
+                info!("Advancing Hold: {:#?} | {:?}", stream, cache);
+
+                // INVARIANT: A Hold with no Peek protecting it invalidates its cache.
+                match cache.back().cloned() {
+                    None => self.advance_stream(stream),
+                    Some(val) => Ok(val),
+                }
+            }
+            Stream::Share(stream) => {
+                info!("Advancing Share: {:#?}", stream);
+
+                let mut stream = stream
+                    .try_borrow_mut()
+                    .context(format!("Could not mutate shared stream"))?;
+                self.advance_stream(&mut stream)
+            }
+        }
+    }
+
+    /// Perform one step of a machine's evaluation.
+    pub fn run_machine(&self, machine: Machine, input: &mut Stream) -> Result<Value> {
+        let val = match machine {
+            Machine::Var(var) => self.run_machine(
+                self.machines
+                    .get(&var)
+                    .cloned()
+                    .ok_or(anyhow!("Undefined fantastic machine: {}", var))?,
+                input,
+            ),
+            Machine::Builtin(builtin) => self.run_builtin_machine(builtin, input),
+            Machine::Defined(body, result) => self.run_defined_machine(body, result, input),
+        }?;
+
+        info!("[EVAL] Machine returned: {:#?}", val);
+        Ok(val)
+    }
+
     /// Perform one step of builtin machine evaluation.
-    pub fn run_builtin_machine(&self, builtin: &Builtin, value: Value) -> Result<Value> {
+    pub fn run_builtin_machine(&self, builtin: Builtin, input: &mut Stream) -> Result<Value> {
+        info!("Running builtin {:#?} with input = {:#?}", builtin, input);
+
+        let value = self.advance_stream(input)?;
         match builtin {
             Builtin::Add => {
                 let (lhs, rhs) = value.to_pair();
@@ -128,126 +341,60 @@ impl Factory {
         }
     }
 
-    /// Run a machine statement, corresponds to one step in the REPL.
-    pub fn run_statement(&self, stmt: &mut Statement) -> Result<Option<Value>> {
-        match stmt {
-            Statement::Let(names, stream) => {
-                if names.len() == 1 {
-                    self.streams
-                        .try_borrow_mut()
-                        .map(|mut ss| ss.insert(names.get(0).unwrap().clone(), stream.clone()))
-                        .with_context(|| format!("Unable to access streams"))?;
-                } else {
-                    for (index, name) in names.iter().enumerate() {
-                        let stream = Stream::Unzip(Box::new(stream.clone()), index);
-                        self.streams
-                            .try_borrow_mut()
-                            .map(|mut ss| ss.insert(name.clone(), stream))
-                            .with_context(|| format!("Unable to access streams"))?;
-                    }
-                }
-                Ok(None)
-            }
-            Statement::Consume(stream) => Ok(Some(self.advance_stream(stream)?)),
-        }
-    }
-
     /// Perform one step of user-supplied machine evaluation.
     pub fn run_defined_machine(
         &self,
-        body: &mut [Statement],
-        result: &mut Stream,
-        value: Value,
+        mut body: Vec<Statement>,
+        mut result: Stream,
+        input: &mut Stream,
     ) -> Result<Value> {
-        self.streams
-            .borrow_mut()
-            .insert("input".to_string(), Stream::Const(value));
+        info!(
+            "Running machine ({:#?}, {:#?}) with input = {:#?}",
+            body, result, input
+        );
 
-        for mut stmt in body {
-            self.run_statement(stmt);
-        }
+        let mut task = Task::new();
 
-        self.advance_stream(result)
-    }
+        // INVARIANT: running a machine always stored its locals on top of the stack.
+        task.bind(String::from("input"), input.clone());
+        self.tasks.borrow_mut().push(task);
+        self.current.borrow_mut().as_mut().map(|x| *x = *x + 1);
 
-    /// Perform one step of a machine's evaluation.
-    pub fn run_machine(&self, machine: &mut Machine, value: Value) -> Result<Value> {
-        match machine {
-            Machine::Var(var) => {
-                let mut machines = self.machines.borrow_mut();
+        for mut stmt in &mut body {
+            match stmt {
+                Statement::Let(names, stream) => {
+                    let mut tasks = self.tasks.borrow_mut();
+                    let index = tasks.len() - 1;
+                    let task = tasks.last_mut().ok_or(anyhow!("Empty task stack"))?;
 
-                info!("[EVAL] about to pull machine `{}` from the factory.", var);
-                info!("[EVAL] factory machines: {:#?}", machines);
-
-                self.run_machine(
-                    machines
-                        .get_mut(var)
-                        .ok_or(anyhow!("Undefined fantastic machine: {}", var))?,
-                    value,
-                )
-            }
-            Machine::Builtin(builtin) => self.run_builtin_machine(builtin, value),
-            Machine::Defined(body, result) => self.run_defined_machine(body, result, value),
-        }
-    }
-
-    /// Get the next element from the stream.
-    pub fn advance_stream(&self, stream: &mut Stream) -> Result<Value> {
-        match stream {
-            Stream::Var(var) => {
-                let mut streams = self
-                    .streams
-                    .try_borrow_mut()
-                    .with_context(|| format!("Unable to access streams"))?;
-
-                info!("[EVAL] about to pull stream `{}` from the factory.", var);
-                info!("[EVAL] factory streams: {:#?}", streams);
-
-                let stream = streams
-                    .get_mut(var)
-                    .ok_or(anyhow!("Undefined fantastic stream: {}", var))?;
-
-                self.advance_stream(stream)
-            }
-            Stream::Const(value) => Ok(value.clone()),
-            Stream::Pipe(stream, machine) => {
-                let value = self.advance_stream(stream)?;
-                self.run_machine(machine, value)
-            }
-            Stream::Zip(streams) => streams
-                .iter_mut()
-                .map(|s| self.advance_stream(s))
-                .collect::<Result<Vec<_>>>()
-                .map(Value::Tuple),
-            Stream::Unzip(stream, index) => {
-                if let Value::Tuple(values) = self.advance_stream(stream)? {
-                    values
-                        .get(*index)
-                        .cloned()
-                        .ok_or(bail!("bad index in unzip: {}", *index))
-                } else {
-                    bail!("called unzip on non-tupled stream: {:?}", stream)
-                }
-            }
-            Stream::Limit(stream, limit) => {
-                if *limit == 0 {
-                    Ok(Value::Null)
-                } else {
-                    *limit -= 1;
-                    self.advance_stream(stream)
-                }
-            }
-            Stream::Cond(cond_stream, then_stream, else_stream) => {
-                if let Value::Bool(cond) = self.advance_stream(cond_stream)? {
-                    if cond {
-                        self.advance_stream(then_stream)
+                    // Now to the tricky part.
+                    if names.len() == 1 {
+                        stream.local(index);
+                        stream.share();
+                        task.bind(names.get(0).unwrap().clone(), stream.clone());
                     } else {
-                        self.advance_stream(else_stream)
+                        for (index, name) in names.iter().enumerate() {
+                            let mut stream = Stream::Proj(Box::new(stream.clone()), index);
+                            stream.local(index);
+                            stream.share();
+                            task.bind(name.clone(), stream);
+                        }
                     }
-                } else {
-                    bail!("non-bool value in conditional")
+                }
+                Statement::Consume(stream) => {
+                    let stream = if stream.is_input() {
+                        &mut *input
+                    } else {
+                        stream
+                    };
+                    self.advance_stream(stream)?;
                 }
             }
         }
+
+        let val = self.advance_stream(&mut result);
+        self.tasks.borrow_mut().pop();
+        self.current.borrow_mut().as_mut().map(|x| *x = *x - 1);
+        val
     }
 }

--- a/bam/src/lexer.rs
+++ b/bam/src/lexer.rs
@@ -21,6 +21,7 @@ lazy_static! {
         "?" => Token::QuestionMark,
         ":" => Token::Colon,
         ";" => Token::Semicolon,
+        "!" => Token::Bang,
         "->" => Token::Pipe,
         "let" => Token::Let,
         "machine" => Token::Machine,
@@ -46,7 +47,8 @@ pub enum Token {
     Semicolon,
     Pipe,
     Machine,
-    Null
+    Null,
+    Bang
 }
 
 impl Display for Token {
@@ -131,6 +133,7 @@ impl LexerBuilder {
             just(":").to(Token::Colon),
             just(";").to(Token::Semicolon),
             just("->").to(Token::Pipe),
+            just("!").to(Token::Bang),
         ))
     }
 

--- a/bam/src/main.rs
+++ b/bam/src/main.rs
@@ -3,7 +3,6 @@ use ansi_term::{Colour, Style};
 use anyhow::{anyhow, bail, Context, Result};
 use chumsky::Parser;
 use clap;
-use eval::Factory;
 use rustyline::{error::ReadlineError, Editor};
 use tracing::{info, level_filters, Level};
 
@@ -83,145 +82,145 @@ enum Mode {
 }
 
 fn run_repl(filename: Option<String>) -> Result<()> {
-    println!("{}", Colour::Purple.bold().paint(BAM));
-    println!("{}", Colour::White.bold().paint(HELP));
-
-    let mut rl = Editor::<()>::new().unwrap();
-
-    let mut type_env = GlobalTypeEnv::new();
-
-    let lexer = LexerBuilder::build();
-    let (program_parser, statement_parser) = ParserBuilder::build();
-
-    let mut factory = Factory::new(Program { machines: vec![] });
-
-    let mut load = |factory: &mut Factory, source: String| {
-        let tokens = lexer.parse(source).unwrap();
-        match program_parser.parse(tokens) {
-            Err(errors) => {
-                let errors = errors
-                    .into_iter()
-                    .map(|err| err.to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n");
-
-                eprintln!(
-                    "{}",
-                    Colour::Red.bold().paint(format!("ParseErrors: {}", errors))
-                );
-            }
-            Ok(program) => {
-                // This should really be a single machine
-                for machine in program.machines {
-                    match types::check_machine_def(&mut type_env, &machine) {
-                        Err(err) => {
-                            eprintln!("{}", Colour::Red.bold().paint(format!("TypeError: {err}")))
-                        }
-                        Ok(()) => factory.bind_definition(machine.name.clone(), machine),
-                    }
-                }
-            }
-        }
-    };
-
-    if let Some(filename) = filename {
-        let source = std::fs::read_to_string(&filename)
-            .with_context(|| format!("Could not load file `{}`", filename))?;
-        load(&mut factory, source);
-    }
-
-    let mut mode = Mode::Statement;
-    let mut definition_buf = String::new();
-
-    let prompt = |mode: &mut Mode| match mode {
-        Mode::Statement => Colour::Blue.bold().paint("bam> ").to_string(),
-        Mode::Streaming(_) => Colour::Purple.bold().paint("BAM!> ").to_string(),
-        Mode::Definiton(l) => {
-            *l += 1;
-            Colour::White.bold().paint(format!("{l} | ")).to_string()
-        }
-    };
-
-    rl.load_history(".history");
-    loop {
-        let current = rl.readline(&prompt(&mut mode));
-        info!("[REPL] handling line: {:?}", &current);
-        match current {
-            Ok(line) if line.trim().is_empty() => {
-                if let Mode::Streaming(ref mut stream) = mode {
-                    if let Statement::Consume(s) = stream {
-                        match factory.advance_stream(s) {
-                            Ok(value) => println!("{}", value),
-                            Err(err) => {
-                                eprintln!("{}", Colour::Red.italic().paint(format!("{err}")))
-                            }
-                        };
-                    } else {
-                        eprintln!(
-                            "{}",
-                            Colour::Red
-                                .italic()
-                                .paint("Cannot run let-statements, for now ...")
-                        )
-                    }
-                }
-            }
-            Ok(line) if line.starts_with(':') => match line.as_str() {
-                ":d" | ":define" => {
-                    mode = Mode::Definiton(0);
-                }
-                _ => eprintln!(
-                    "{}",
-                    Colour::Red
-                        .bold()
-                        .paint(format!("Unknown command: `{}`", &line[1..]))
-                ),
-            },
-            Ok(line) if matches!(mode, Mode::Definiton(_)) => {
-                definition_buf.push_str(&line);
-            }
-            Ok(line) if matches!(mode, Mode::Statement) => {
-                rl.add_history_entry(line.as_str());
-
-                let tokens = lexer.parse(line).unwrap();
-                match statement_parser.parse(tokens) {
-                    Err(errors) => eprintln!(
-                        "{}\n{}",
-                        Colour::Red.bold().paint("ParseError:"),
-                        errors
-                            .into_iter()
-                            .map(|err| { err.to_string() })
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    ),
-                    Ok(stream) => mode = Mode::Streaming(stream),
-                }
-            }
-            Err(ReadlineError::Eof) if matches!(mode, Mode::Streaming(_)) => mode = Mode::Statement,
-            Err(ReadlineError::Eof) if matches!(mode, Mode::Definiton(_)) => {
-                let lines = definition_buf.drain(..).collect::<String>();
-                rl.add_history_entry(lines.as_str());
-                load(&mut factory, lines);
-                mode = Mode::Statement
-            }
-            Err(ReadlineError::Interrupted) => {
-                // Ctrl+C shouldn't crash the REPL
-            }
-            Err(ReadlineError::Eof) => {
-                println!("{}", Style::new().italic().paint("Exiting ..."));
-                rl.save_history(".history").is_ok();
-                break;
-            }
-            error => {
-                rl.save_history(".history").is_ok();
-                error
-                    .map(|_| ())
-                    .with_context(|| format!("Unexpected error while reading input"))?;
-            }
-        }
-    }
-
-    rl.save_history(".history");
+    // println!("{}", Colour::Purple.bold().paint(BAM));
+    // println!("{}", Colour::White.bold().paint(HELP));
+    //
+    // let mut rl = Editor::<()>::new().unwrap();
+    //
+    // let mut type_env = GlobalTypeEnv::new();
+    //
+    // let lexer = LexerBuilder::build();
+    // let (program_parser, statement_parser) = ParserBuilder::build();
+    //
+    // let mut factory = Factory::new(Program { machines: vec![] });
+    //
+    // let mut load = |factory: &mut Factory, source: String| {
+    //     let tokens = lexer.parse(source).unwrap();
+    //     match program_parser.parse(tokens) {
+    //         Err(errors) => {
+    //             let errors = errors
+    //                 .into_iter()
+    //                 .map(|err| err.to_string())
+    //                 .collect::<Vec<_>>()
+    //                 .join("\n");
+    //
+    //             eprintln!(
+    //                 "{}",
+    //                 Colour::Red.bold().paint(format!("ParseErrors: {}", errors))
+    //             );
+    //         }
+    //         Ok(program) => {
+    //             // This should really be a single machine
+    //             for machine in program.machines {
+    //                 match types::check_machine_def(&mut type_env, &machine) {
+    //                     Err(err) => {
+    //                         eprintln!("{}", Colour::Red.bold().paint(format!("TypeError: {err}")))
+    //                     }
+    //                     Ok(()) => factory.bind_definition(machine.name.clone(), machine),
+    //                 }
+    //             }
+    //         }
+    //     }
+    // };
+    //
+    // if let Some(filename) = filename {
+    //     let source = std::fs::read_to_string(&filename)
+    //         .with_context(|| format!("Could not load file `{}`", filename))?;
+    //     load(&mut factory, source);
+    // }
+    //
+    // let mut mode = Mode::Statement;
+    // let mut definition_buf = String::new();
+    //
+    // let prompt = |mode: &mut Mode| match mode {
+    //     Mode::Statement => Colour::Blue.bold().paint("bam> ").to_string(),
+    //     Mode::Streaming(_) => Colour::Purple.bold().paint("BAM!> ").to_string(),
+    //     Mode::Definiton(l) => {
+    //         *l += 1;
+    //         Colour::White.bold().paint(format!("{l} | ")).to_string()
+    //     }
+    // };
+    //
+    // rl.load_history(".history");
+    // loop {
+    //     let current = rl.readline(&prompt(&mut mode));
+    //     info!("[REPL] handling line: {:?}", &current);
+    //     match current {
+    //         Ok(line) if line.trim().is_empty() => {
+    //             if let Mode::Streaming(ref mut stream) = mode {
+    //                 if let Statement::Consume(s) = stream {
+    //                     match factory.advance_stream(s) {
+    //                         Ok(value) => println!("{}", value),
+    //                         Err(err) => {
+    //                             eprintln!("{}", Colour::Red.italic().paint(format!("{err}")))
+    //                         }
+    //                     };
+    //                 } else {
+    //                     eprintln!(
+    //                         "{}",
+    //                         Colour::Red
+    //                             .italic()
+    //                             .paint("Cannot run let-statements, for now ...")
+    //                     )
+    //                 }
+    //             }
+    //         }
+    //         Ok(line) if line.starts_with(':') => match line.as_str() {
+    //             ":d" | ":define" => {
+    //                 mode = Mode::Definiton(0);
+    //             }
+    //             _ => eprintln!(
+    //                 "{}",
+    //                 Colour::Red
+    //                     .bold()
+    //                     .paint(format!("Unknown command: `{}`", &line[1..]))
+    //             ),
+    //         },
+    //         Ok(line) if matches!(mode, Mode::Definiton(_)) => {
+    //             definition_buf.push_str(&line);
+    //         }
+    //         Ok(line) if matches!(mode, Mode::Statement) => {
+    //             rl.add_history_entry(line.as_str());
+    //
+    //             let tokens = lexer.parse(line).unwrap();
+    //             match statement_parser.parse(tokens) {
+    //                 Err(errors) => eprintln!(
+    //                     "{}\n{}",
+    //                     Colour::Red.bold().paint("ParseError:"),
+    //                     errors
+    //                         .into_iter()
+    //                         .map(|err| { err.to_string() })
+    //                         .collect::<Vec<_>>()
+    //                         .join("\n")
+    //                 ),
+    //                 Ok(stream) => mode = Mode::Streaming(stream),
+    //             }
+    //         }
+    //         Err(ReadlineError::Eof) if matches!(mode, Mode::Streaming(_)) => mode = Mode::Statement,
+    //         Err(ReadlineError::Eof) if matches!(mode, Mode::Definiton(_)) => {
+    //             let lines = definition_buf.drain(..).collect::<String>();
+    //             rl.add_history_entry(lines.as_str());
+    //             load(&mut factory, lines);
+    //             mode = Mode::Statement
+    //         }
+    //         Err(ReadlineError::Interrupted) => {
+    //             // Ctrl+C shouldn't crash the REPL
+    //         }
+    //         Err(ReadlineError::Eof) => {
+    //             println!("{}", Style::new().italic().paint("Exiting ..."));
+    //             rl.save_history(".history").is_ok();
+    //             break;
+    //         }
+    //         error => {
+    //             rl.save_history(".history").is_ok();
+    //             error
+    //                 .map(|_| ())
+    //                 .with_context(|| format!("Unexpected error while reading input"))?;
+    //         }
+    //     }
+    // }
+    //
+    // rl.save_history(".history");
     Ok(())
 }
 
@@ -246,16 +245,16 @@ fn run(path: &str) {
         Err(err) => println!("Type Error: {err:#?}"),
     }
 
-    let mut factory = eval::Factory::new(program);
-
-    loop {
-        let result = factory.advance_stream(&mut Stream::Pipe(
-            Stream::Const(Value::Num(42f64)).into(),
-            Machine::Var("Main".to_string()).into(),
-        ));
-
-        info!("[STEP]: {result:#?}");
-    }
+    // // let mut factory = eval::Factory::new(program);
+    //
+    // loop {
+    //     let result = factory.advance_stream(&mut Stream::Pipe(
+    //         Stream::Const(Value::Num(42f64)).into(),
+    //         Machine::Var("Main".to_string()).into(),
+    //     ));
+    //
+    //     info!("[STEP]: {result:#?}");
+    // }
 }
 
 #[cfg(test)]

--- a/bam/src/parser.rs
+++ b/bam/src/parser.rs
@@ -31,9 +31,13 @@ impl ParserBuilder {
                 .then_ignore(just(Token::Lbrace))
                 .then(Self::int())
                 .then_ignore(just(Token::Rbrace))
-                .map(|(stream, count)| Stream::Limit(Box::new(stream), count));
+                .map(|(stream, count)| Stream::Take(Box::new(stream), count));
 
-            let stream_limit = limit.or(stream_leaf.clone()).boxed();
+            let peek = just(Token::Bang)
+                .ignore_then(stream_leaf.clone())
+                .map(|stream| Stream::Peek(Box::new(stream)));
+
+            let stream_limit = peek.or(limit.or(stream_leaf.clone())).boxed();
 
             let stream_zip = stream_limit
                 .clone()

--- a/bam/src/syntax.rs
+++ b/bam/src/syntax.rs
@@ -35,20 +35,6 @@ pub enum Stream {
     /// Read a value from the underlying stream
     /// without consuming it.
     Peek(Box<Stream>), // !s
-
-    /* Only generated during evaluation. */
-    /// Contains the original stream to unzip,
-    /// and the index with which to project.
-    Proj(Box<Stream>, usize), // let x, y = s
-
-    /// A stream that caches returned values.
-    Hold(Box<Stream>, VecDeque<Value>),
-
-    /// A stream that can be sneakily mutated.
-    Share(Rc<RefCell<Stream>>),
-
-    /// A Stream plus an index to the task it was created in.
-    Local(Box<Stream>, usize),
 }
 
 impl Default for Stream {
@@ -65,33 +51,12 @@ impl Stream {
             _ => false,
         }
     }
-
-    /// Transforms a stream in place to be `Share`.
-    pub fn share(&mut self) {
-        if let Self::Share(_) = self {
-            return;
-        }
-        let old_stream = std::mem::take(self);
-        /* Nothing should/would access the stream here, it's Null */
-        let new_stream = Self::Share(Rc::new(RefCell::new(old_stream)));
-        std::mem::replace(self, new_stream);
-    }
-
-    /// Transforms a stream in place to be `Local`.
-    pub fn local(&mut self, index: usize) {
-        let old_stream = std::mem::take(self);
-        /* Nothing should/would access the stream here, it's Null */
-        let new_stream = Self::Local(Box::new(old_stream), index);
-        std::mem::replace(self, new_stream);
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Machine {
     Var(String),
     Builtin(Builtin),
-    /// Only generated during evaluation.
-    Defined(Vec<Statement>, Stream),
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]

--- a/bam/src/types.rs
+++ b/bam/src/types.rs
@@ -338,9 +338,6 @@ fn infer_stream(
                 },
                 Machine::Builtin(builtin) => Ok(get_builtin_ty(builtin)
                     .unwrap_or_else(|| panic!("{builtin:#?} not found in BUILTIN_MAP"))),
-                Machine::Defined(_, _) => panic!(
-                    "infer_stream: Machine::Defined should not be able to appear in source files"
-                ),
             }?;
             let machine_ty = instantiate(local_env, machine_ty);
 
@@ -375,12 +372,8 @@ fn infer_stream(
             // equivalent, it doesn't matter which one we return here. We arbitrarily pick the 'then' branch.
             Ok(then_ty)
         }
-        Stream::Take(stream, _) | Stream::Peek(stream) | Stream::Hold(stream, _) => {
+        Stream::Take(stream, _) | Stream::Peek(stream) => {
             infer_stream(global_env, local_env, stream)
-        }
-
-        Stream::Proj(_, _) | Stream::Local(_, _) | Stream::Share(_) => {
-            panic!("infer_stream: should not be able to appear in source files")
         }
     }
 }

--- a/bam/src/vm.rs
+++ b/bam/src/vm.rs
@@ -1,0 +1,21 @@
+///! BAM! virtual machine.
+use std::{cell::RefCell, rc::Rc};
+
+use crate::compiler::{Flow, Unit};
+use lazy_static::lazy_static;
+
+/// A reference-counted, mutable stream in memory.
+pub struct SharedStream(Rc<RefCell<Flow>>);
+
+/// The execution context of one machine.
+pub struct Task {
+    /// Locally-reachable streams, indexed by symbols.
+    locals: Vec<SharedStream>,
+}
+
+/// Execution factory.
+pub struct Factory {
+    /// Call stack.
+    stack: Vec<Task>,
+}
+

--- a/bam/src/vm.rs
+++ b/bam/src/vm.rs
@@ -1,11 +1,23 @@
 ///! BAM! virtual machine.
-use std::{cell::RefCell, rc::Rc};
+use std::{cell::RefCell, collections::VecDeque, rc::Rc};
 
-use crate::compiler::{Flow, Unit};
+use crate::{
+    compiler::{Flow, Unit},
+    Value,
+};
 use lazy_static::lazy_static;
 
 /// A reference-counted, mutable stream in memory.
-pub struct SharedStream(Rc<RefCell<Flow>>);
+pub struct SharedStream {
+    data: Rc<RefCell<Flow>>,
+    // TODO: make this Optional
+    // by adding a `Hold` instr to create it only when necessary:
+    // Make a flow peekable, invloves adding a cache for it.
+    // This is only observable through `Peek` flows. Everyone
+    // else who holds the handle will consume from the stream normally.
+    // Hold(Handle)
+    cache: VecDeque<Value>,
+}
 
 /// The execution context of one machine.
 pub struct Task {
@@ -18,4 +30,3 @@ pub struct Factory {
     /// Call stack.
     stack: Vec<Task>,
 }
-


### PR DESCRIPTION
This is a tracking PR for running BAM! on a very high level virtual machine.

- `compiler.rs` would turn the syntax tree into a flatter, more machine friendly (get it?) representation.
- `vm.rs` would ... run that format.

